### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
 });
-services.AddSwaggerGenNewtonsoftSupport() // explicit opt-in - needs to be placed after AddSwaggerGen()
+services.AddSwaggerGenNewtonsoftSupport(); // explicit opt-in - needs to be placed after AddSwaggerGen()
 ```
 
 # Swashbuckle, ApiExplorer, and Routing #


### PR DESCRIPTION
Missing semicolon at the end of a line of code